### PR TITLE
feat: add ProductGroup (PRDGRP)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ProductGroup (PRDGRP)
 
 
 2.1.0 (2024-05-31)

--- a/src/gocept/collmex/collmex.py
+++ b/src/gocept/collmex/collmex.py
@@ -215,6 +215,11 @@ class Collmex:
             price_group,
             0, self.system_identifier)
 
+    def get_product_groups(self):
+        return self._query_objects(
+            'PRODUCT_GROUPS_GET',
+            0, self.system_identifier)
+
     def get_customer_agreements(self, customer_id=NULL, product_id=NULL,
                                 valid_on_date=NULL, inactive=NULL,
                                 only_changed=NULL):

--- a/src/gocept/collmex/doctest.rst
+++ b/src/gocept/collmex/doctest.rst
@@ -90,6 +90,17 @@ Products are created using the ``create_product`` method:
 >>> collmex.get_products()[0]['Bezeichnung']
 'Testprodukt'
 
+Product Groups
+--------------
+>>> group = gocept.collmex.model.ProductGroup()
+>>> group['Produktgruppe Nr'] = '2'
+>>> group['Bezeichnung'] = 'Testproduktgruppe'
+>>> group['Untergruppe von'] = 'Hauptproduktgruppe'
+>>> collmex.create(group)
+>>> transaction.commit()
+>>> collmex.get_product_groups()[-1]['Bezeichnung']
+'Testproduktgruppe'
+
 Customer Agreements
 -------------------
 

--- a/src/gocept/collmex/interfaces.py
+++ b/src/gocept/collmex/interfaces.py
@@ -66,6 +66,10 @@ class IProduct(IModel):
     """A product (CMXPRD)."""
 
 
+class IProductGroup(IModel):
+    """A product group (PRDGRP)."""
+
+
 class ICustomerAgreement(IModel):
     """A customer agreement (CMXCAG)."""
 

--- a/src/gocept/collmex/model.py
+++ b/src/gocept/collmex/model.py
@@ -325,6 +325,18 @@ class Product(Model):
         self['Firma'] = company_id
 
 
+@zope.interface.implementer(gocept.collmex.interfaces.IProductGroup)
+class ProductGroup(Model):
+
+    satzart = 'PRDGRP'
+    fields = (
+        'Satzart',
+        'Produktgruppe Nr',
+        'Bezeichnung',
+        'Untergruppe von',
+    )
+
+
 @zope.interface.implementer(gocept.collmex.interfaces.ICustomerAgreement)
 class CustomerAgreement(Model):
 


### PR DESCRIPTION
```python
>>> group = gocept.collmex.model.ProductGroup()
>>> group['Produktgruppe Nr'] = '2'
>>> group['Bezeichnung'] = 'Testproduktgruppe'
>>> group['Untergruppe von'] = 'Hauptproduktgruppe'
>>> collmex.create(group)
>>> transaction.commit()
>>> collmex.get_product_groups()[-1]['Bezeichnung']
'Testproduktgruppe'
```