### PR TITLE
fix security issue: fix login if password or username contains ";"

### DIFF
--- a/src/gocept/collmex/collmex.py
+++ b/src/gocept/collmex/collmex.py
@@ -319,7 +319,9 @@ class Collmex:
         data = (data.decode('UTF-8')
                 if isinstance(data, bytes)
                 else data)
-        data = 'LOGIN;{};{}\n'.format(self.username, self.password) + data
+        login = io.StringIO()
+        csv.writer(login, dialect=CollmexDialect).writerow(['LOGIN', self.username, self.password])
+        data = login.getvalue() + data
         log.debug(data.replace(self.password, '<PASSWORD>'))
         content_type, body = gocept.collmex.utils.encode_multipart_formdata(
             [], [('fileName', 'api.csv', data)])


### PR DESCRIPTION
The login doesn't work if the username or password contains a ";" because invalid CSV syntax is produced.
When the username or password is provided by user input this would allow CSV injection.